### PR TITLE
Explorer for xrp update: Replace ripplecharts with bithomp

### DIFF
--- a/WirexUtils/CryptoCurrency/Xpr/XrpHelperUrls.swift
+++ b/WirexUtils/CryptoCurrency/Xpr/XrpHelperUrls.swift
@@ -11,7 +11,7 @@ import Foundation
 private enum XrpHelperUrlsConstants {
     static let rippleScheme = ""//"ripple:"
     static let tagArgument = "?dt="
-    static let baseXrpChartsUrlString = "https://xrpcharts.ripple.com/#/transactions/"
+    static let baseXrpChartsUrlString = "https://bithomp.com/explorer/"
 }
 
 public struct XrpHelperUrls {


### PR DESCRIPTION
Explorer for xrp update: Replace ripplecharts with bithomp. 
Ledger live and Edge wallet and many others use bithomp, its more userfriendly.